### PR TITLE
增加忽略的文件夹

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+.idea/
+.pycharm_helpers
+/.idea/misc.xml
+/.idea/vcs.xml


### PR DESCRIPTION
在.gitignore中增加项目产生的临时文件夹，不提交到远程仓库中